### PR TITLE
Wrap main content in semantic main element

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
   <header class="fixed top-0 inset-x-0 z-40">
     <nav class="glass border-b border-white/40">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center gap-4">
-        <a href="#home" class="font-extrabold tracking-tight text-xl">Step3D</a>
+        <a href="#main-content" class="font-extrabold tracking-tight text-xl">Step3D</a>
         <div class="hidden md:flex items-center gap-6 ml-6 text-sm">
           <a href="#problem" class="hover:text-brand-700">Проблема</a>
           <a href="#solution" class="hover:text-brand-700">Решение</a>
@@ -76,247 +76,249 @@
     </nav>
   </header>
 
-  <!-- Hero -->
-  <section id="home" class="pt-28 md:pt-32">
-    <div class="mx-auto max-w-7xl px-4">
-      <div class="grid md:grid-cols-2 gap-8 items-center">
-        <div class="reveal">
-          <h1 class="text-3xl md:text-5xl font-extrabold leading-tight">
-            Устройство для <span class="text-brand-600">доступа к ПММ</span> без наклонов
-          </h1>
-          <p class="mt-4 text-slate-600">
-            Мобильная платформа с регулируемым подъёмом корзины: меньше наклонов — меньше боли в спине. Эргономично, эстетично и экономично.
-          </p>
-          <div class="mt-6 flex flex-wrap gap-3">
-            <span class="inline-flex items-center gap-2 text-sm bg-white rounded-xl px-3 py-2 shadow-soft">
-              ✓ Мобильность: колёса с фиксатором
-            </span>
-            <span class="inline-flex items-center gap-2 text-sm bg-white rounded-xl px-3 py-2 shadow-soft">
-              ✓ Газовые амортизаторы
-            </span>
-            <span class="inline-flex items-center gap-2 text-sm bg-white rounded-xl px-3 py-2 shadow-soft">
-              ✓ Совместимость 45/60 см
-            </span>
+  <main id="main-content" class="pt-28 md:pt-32">
+    <!-- Hero -->
+    <section id="home">
+      <div class="mx-auto max-w-7xl px-4">
+        <div class="grid md:grid-cols-2 gap-8 items-center">
+          <div class="reveal">
+            <h1 class="text-3xl md:text-5xl font-extrabold leading-tight">
+              Устройство для <span class="text-brand-600">доступа к ПММ</span> без наклонов
+            </h1>
+            <p class="mt-4 text-slate-600">
+              Мобильная платформа с регулируемым подъёмом корзины: меньше наклонов — меньше боли в спине. Эргономично, эстетично и экономично.
+            </p>
+            <div class="mt-6 flex flex-wrap gap-3">
+              <span class="inline-flex items-center gap-2 text-sm bg-white rounded-xl px-3 py-2 shadow-soft">
+                ✓ Мобильность: колёса с фиксатором
+              </span>
+              <span class="inline-flex items-center gap-2 text-sm bg-white rounded-xl px-3 py-2 shadow-soft">
+                ✓ Газовые амортизаторы
+              </span>
+              <span class="inline-flex items-center gap-2 text-sm bg-white rounded-xl px-3 py-2 shadow-soft">
+                ✓ Совместимость 45/60 см
+              </span>
+            </div>
+            <div class="mt-7 flex gap-3">
+              <a href="#roadmap" class="px-4 py-2 rounded-2xl border border-brand-200 text-brand-700 bg-brand-50 hover:bg-brand-100">Дорожная карта</a>
+              <a href="https://t.me/step_3d_mngr" target="_blank" rel="noopener" class="px-4 py-2 rounded-2xl bg-brand-600 hover:bg-brand-700 text-white shadow-soft">Связаться</a>
+            </div>
           </div>
-          <div class="mt-7 flex gap-3">
-            <a href="#roadmap" class="px-4 py-2 rounded-2xl border border-brand-200 text-brand-700 bg-brand-50 hover:bg-brand-100">Дорожная карта</a>
-            <a href="https://t.me/step_3d_mngr" target="_blank" rel="noopener" class="px-4 py-2 rounded-2xl bg-brand-600 hover:bg-brand-700 text-white shadow-soft">Связаться</a>
-          </div>
-        </div>
 
-        <!-- Simple interactive mock (height slider) -->
-        <div class="reveal">
-          <div class="relative rounded-3xl bg-gradient-to-br from-brand-50 to-white p-6 shadow-soft">
-            <div class="absolute inset-0 rounded-3xl ring-1 ring-black/5 pointer-events-none"></div>
-            <h3 class="font-semibold mb-3">Интерактивное демо (эскиз)</h3>
-            <div class="grid md:grid-cols-[1fr_auto] gap-5">
-              <div class="relative bg-white rounded-2xl p-4 ring-1 ring-slate-100">
-                <div class="h-64 md:h-72 relative">
-                  <!-- Base -->
-                  <div class="absolute bottom-0 inset-x-4 h-4 bg-slate-200 rounded-full"></div>
-                  <!-- Post -->
-                  <div id="post" class="absolute bottom-4 left-1/2 -translate-x-1/2 w-2 bg-slate-300 rounded-md" style="height: 160px;"></div>
-                  <!-- Basket -->
-                  <div id="basket" class="absolute left-1/2 -translate-x-1/2 w-40 h-20 bg-gradient-to-br from-slate-50 to-slate-200 rounded-xl shadow" style="bottom: 150px;"></div>
+          <!-- Simple interactive mock (height slider) -->
+          <div class="reveal">
+            <div class="relative rounded-3xl bg-gradient-to-br from-brand-50 to-white p-6 shadow-soft">
+              <div class="absolute inset-0 rounded-3xl ring-1 ring-black/5 pointer-events-none"></div>
+              <h3 class="font-semibold mb-3">Интерактивное демо (эскиз)</h3>
+              <div class="grid md:grid-cols-[1fr_auto] gap-5">
+                <div class="relative bg-white rounded-2xl p-4 ring-1 ring-slate-100">
+                  <div class="h-64 md:h-72 relative">
+                    <!-- Base -->
+                    <div class="absolute bottom-0 inset-x-4 h-4 bg-slate-200 rounded-full"></div>
+                    <!-- Post -->
+                    <div id="post" class="absolute bottom-4 left-1/2 -translate-x-1/2 w-2 bg-slate-300 rounded-md" style="height: 160px;"></div>
+                    <!-- Basket -->
+                    <div id="basket" class="absolute left-1/2 -translate-x-1/2 w-40 h-20 bg-gradient-to-br from-slate-50 to-slate-200 rounded-xl shadow" style="bottom: 150px;"></div>
+                  </div>
                 </div>
-              </div>
-              <div class="flex flex-col justify-between">
-                <label for="height" class="text-sm text-slate-600">Высота подъёма</label>
-                <input id="height" type="range" min="0" max="100" value="40" class="w-40 accent-brand-600">
-                <div class="text-sm"><span id="heightVal" class="font-semibold">40%</span></div>
-                <p class="text-xs text-slate-500">Эскиз. Цель — показать идею подъёма корзины.</p>
+                <div class="flex flex-col justify-between">
+                  <label for="height" class="text-sm text-slate-600">Высота подъёма</label>
+                  <input id="height" type="range" min="0" max="100" value="40" class="w-40 accent-brand-600">
+                  <div class="text-sm"><span id="heightVal" class="font-semibold">40%</span></div>
+                  <p class="text-xs text-slate-500">Эскиз. Цель — показать идею подъёма корзины.</p>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <!-- Badges -->
-      <div class="mt-10 grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div class="bg-white rounded-2xl p-4 shadow-soft text-center">
-          <div class="text-3xl font-extrabold text-brand-700">–60%</div>
-          <div class="text-xs text-slate-500 mt-1">снижение нагрузки на поясницу</div>
-        </div>
-        <div class="bg-white rounded-2xl p-4 shadow-soft text-center">
-          <div class="text-3xl font-extrabold text-brand-700">45/60</div>
-          <div class="text-xs text-slate-500 mt-1">совместимость ПММ, узк./полноразм.</div>
-        </div>
-        <div class="bg-white rounded-2xl p-4 shadow-soft text-center">
-          <div class="text-3xl font-extrabold text-brand-700">AISI 304</div>
-          <div class="text-xs text-slate-500 mt-1">каркас из нержавеющей стали</div>
-        </div>
-        <div class="bg-white rounded-2xl p-4 shadow-soft text-center">
-          <div class="text-3xl font-extrabold text-brand-700">ЛДСП</div>
-          <div class="text-xs text-slate-500 mt-1">влагостойкая облицовка</div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Problem -->
-  <section id="problem" class="py-16 md:py-24">
-    <div class="mx-auto max-w-7xl px-4 grid md:grid-cols-2 gap-10 items-start">
-      <div class="reveal">
-        <h2 class="text-2xl md:text-3xl font-extrabold">Проблема</h2>
-        <p class="mt-4 text-slate-600">
-          Многократные наклоны при загрузке/выгрузке ПММ приводят к болям в спине и рискам травм. Особенно актуально для пожилых и людей с ОДА.
-        </p>
-        <ul class="mt-4 space-y-2 text-slate-700">
-          <li>• Хроническая нагрузка на поясницу</li>
-          <li>• Ограниченное пространство небольших кухонь</li>
-          <li>• Отсутствие эстетичных бытовых решений</li>
-        </ul>
-      </div>
-      <div class="reveal">
-        <div class="bg-white rounded-3xl p-6 shadow-soft ring-1 ring-slate-100">
-          <h3 class="font-semibold">Мы решаем это</h3>
-          <p class="mt-2 text-slate-600">Подъём корзины на комфортный уровень без усилий и наклонов.</p>
-          <div class="mt-4 grid grid-cols-2 gap-3">
-            <span class="text-sm bg-brand-50 text-brand-700 px-3 py-2 rounded-xl">Безопасность</span>
-            <span class="text-sm bg-brand-50 text-brand-700 px-3 py-2 rounded-xl">Эргономика</span>
-            <span class="text-sm bg-brand-50 text-brand-700 px-3 py-2 rounded-xl">Эстетика</span>
-            <span class="text-sm bg-brand-50 text-brand-700 px-3 py-2 rounded-xl">Комфорт</span>
+        <!-- Badges -->
+        <div class="mt-10 grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div class="bg-white rounded-2xl p-4 shadow-soft text-center">
+            <div class="text-3xl font-extrabold text-brand-700">–60%</div>
+            <div class="text-xs text-slate-500 mt-1">снижение нагрузки на поясницу</div>
+          </div>
+          <div class="bg-white rounded-2xl p-4 shadow-soft text-center">
+            <div class="text-3xl font-extrabold text-brand-700">45/60</div>
+            <div class="text-xs text-slate-500 mt-1">совместимость ПММ, узк./полноразм.</div>
+          </div>
+          <div class="bg-white rounded-2xl p-4 shadow-soft text-center">
+            <div class="text-3xl font-extrabold text-brand-700">AISI 304</div>
+            <div class="text-xs text-slate-500 mt-1">каркас из нержавеющей стали</div>
+          </div>
+          <div class="bg-white rounded-2xl p-4 shadow-soft text-center">
+            <div class="text-3xl font-extrabold text-brand-700">ЛДСП</div>
+            <div class="text-xs text-slate-500 mt-1">влагостойкая облицовка</div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Solution & Specs -->
-  <section id="solution" class="py-8">
-    <div class="mx-auto max-w-7xl px-4">
-      <div class="reveal bg-white rounded-3xl p-6 md:p-10 shadow-soft ring-1 ring-slate-100">
-        <h2 class="text-2xl md:text-3xl font-extrabold">Решение</h2>
-        <p class="mt-3 text-slate-600">
-          Мобильная платформа с плавным газовым подъёмом. Подходит для ПММ 45/60 см, компактно убирается, легко перемещается.
-        </p>
-        <div class="mt-6 grid sm:grid-cols-3 gap-4">
-          <div class="rounded-2xl bg-slate-50 p-4">
-            <div class="text-sm text-slate-500">Подъёмный механизм</div>
-            <div class="font-semibold">Газовые амортизаторы</div>
-            <p class="text-sm text-slate-600 mt-1">Плавность и регулируемое усилие.</p>
-          </div>
-          <div class="rounded-2xl bg-slate-50 p-4">
-            <div class="text-sm text-slate-500">Каркас</div>
-            <div class="font-semibold">Нержавеющая сталь AISI 304</div>
-            <p class="text-sm text-slate-600 mt-1">Долговечность и устойчивость к коррозии.</p>
-          </div>
-          <div class="rounded-2xl bg-slate-50 p-4">
-            <div class="text-sm text-slate-500">Облицовка</div>
-            <div class="font-semibold">Влагостойкая ЛДСП/МДФ</div>
-            <p class="text-sm text-slate-600 mt-1">Широкий выбор текстур и цветов.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section id="specs" class="py-8">
-    <div class="mx-auto max-w-7xl px-4">
-      <div class="reveal grid md:grid-cols-2 gap-6">
-        <div class="bg-white rounded-3xl p-6 shadow-soft ring-1 ring-slate-100">
-          <h3 class="font-semibold">Технические характеристики</h3>
-          <ul class="mt-3 space-y-2 text-slate-700 text-sm">
-            <li>• Диапазон подъёма: 0–350 мм (настройка)</li>
-            <li>• Грузоподъёмность: 10–15 кг (домашняя ПММ)</li>
-            <li>• Габариты: компактные, проходят в стандартные проёмы</li>
-            <li>• Колёса: поворотные, фиксируемые</li>
-            <li>• Безопасность: демпфирование, механическая блокировка</li>
+    <!-- Problem -->
+    <section id="problem" class="py-16 md:py-24">
+      <div class="mx-auto max-w-7xl px-4 grid md:grid-cols-2 gap-10 items-start">
+        <div class="reveal">
+          <h2 class="text-2xl md:text-3xl font-extrabold">Проблема</h2>
+          <p class="mt-4 text-slate-600">
+            Многократные наклоны при загрузке/выгрузке ПММ приводят к болям в спине и рискам травм. Особенно актуально для пожилых и людей с ОДА.
+          </p>
+          <ul class="mt-4 space-y-2 text-slate-700">
+            <li>• Хроническая нагрузка на поясницу</li>
+            <li>• Ограниченное пространство небольших кухонь</li>
+            <li>• Отсутствие эстетичных бытовых решений</li>
           </ul>
         </div>
-        <div class="bg-gradient-to-br from-brand-50 to-white rounded-3xl p-6 shadow-soft ring-1 ring-slate-100">
-          <h3 class="font-semibold">Преимущества</h3>
-          <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
-            <div class="bg-white rounded-2xl p-3 shadow">Снижение нагрузки на поясницу</div>
-            <div class="bg-white rounded-2xl p-3 shadow">Чистый внешний вид</div>
-            <div class="bg-white rounded-2xl p-3 shadow">Простая интеграция</div>
-            <div class="bg-white rounded-2xl p-3 shadow">Доступная себестоимость</div>
+        <div class="reveal">
+          <div class="bg-white rounded-3xl p-6 shadow-soft ring-1 ring-slate-100">
+            <h3 class="font-semibold">Мы решаем это</h3>
+            <p class="mt-2 text-slate-600">Подъём корзины на комфортный уровень без усилий и наклонов.</p>
+            <div class="mt-4 grid grid-cols-2 gap-3">
+              <span class="text-sm bg-brand-50 text-brand-700 px-3 py-2 rounded-xl">Безопасность</span>
+              <span class="text-sm bg-brand-50 text-brand-700 px-3 py-2 rounded-xl">Эргономика</span>
+              <span class="text-sm bg-brand-50 text-brand-700 px-3 py-2 rounded-xl">Эстетика</span>
+              <span class="text-sm bg-brand-50 text-brand-700 px-3 py-2 rounded-xl">Комфорт</span>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Roadmap -->
-  <section id="roadmap" class="py-16 md:py-24 bg-white">
-    <div class="mx-auto max-w-7xl px-4">
-      <div class="reveal text-center">
-        <h2 class="text-2xl md:text-3xl font-extrabold">Дорожная карта</h2>
-        <p class="mt-3 text-slate-600">Этапы от исследования до серийного запуска.</p>
-      </div>
-
-      <!-- Progress timeline -->
-      <ol class="mt-10 relative border-s-2 border-brand-100 ps-6">
-        <!-- 1 -->
-        <li class="mb-10 ms-6 reveal">
-          <span class="absolute -start-3 top-0 flex h-6 w-6 items-center justify-center rounded-full bg-brand-600 text-white text-xs">1</span>
-          <h3 class="font-semibold">Исследование и UX <span class="text-slate-400 font-normal">· 1–2 мес</span></h3>
-          <p class="text-slate-600 text-sm mt-1">Опросы, фокус-группы, анализ патентов, сценарии использования.</p>
-          <div class="mt-2 w-full h-2 bg-slate-100 rounded-full overflow-hidden">
-            <div class="h-2 bg-brand-400 w-[85%]"></div>
+    <!-- Solution & Specs -->
+    <section id="solution" class="py-8">
+      <div class="mx-auto max-w-7xl px-4">
+        <div class="reveal bg-white rounded-3xl p-6 md:p-10 shadow-soft ring-1 ring-slate-100">
+          <h2 class="text-2xl md:text-3xl font-extrabold">Решение</h2>
+          <p class="mt-3 text-slate-600">
+            Мобильная платформа с плавным газовым подъёмом. Подходит для ПММ 45/60 см, компактно убирается, легко перемещается.
+          </p>
+          <div class="mt-6 grid sm:grid-cols-3 gap-4">
+            <div class="rounded-2xl bg-slate-50 p-4">
+              <div class="text-sm text-slate-500">Подъёмный механизм</div>
+              <div class="font-semibold">Газовые амортизаторы</div>
+              <p class="text-sm text-slate-600 mt-1">Плавность и регулируемое усилие.</p>
+            </div>
+            <div class="rounded-2xl bg-slate-50 p-4">
+              <div class="text-sm text-slate-500">Каркас</div>
+              <div class="font-semibold">Нержавеющая сталь AISI 304</div>
+              <p class="text-sm text-slate-600 mt-1">Долговечность и устойчивость к коррозии.</p>
+            </div>
+            <div class="rounded-2xl bg-slate-50 p-4">
+              <div class="text-sm text-slate-500">Облицовка</div>
+              <div class="font-semibold">Влагостойкая ЛДСП/МДФ</div>
+              <p class="text-sm text-slate-600 mt-1">Широкий выбор текстур и цветов.</p>
+            </div>
           </div>
-        </li>
-        <!-- 2 -->
-        <li class="mb-10 ms-6 reveal">
-          <span class="absolute -start-3 top-0 flex h-6 w-6 items-center justify-center rounded-full bg-brand-600 text-white text-xs">2</span>
-          <h3 class="font-semibold">Проектирование <span class="text-slate-400 font-normal">· 2–3 мес</span></h3>
-          <p class="text-slate-600 text-sm mt-1">3D-модели, чертежи, выбор поставщиков, расчёт себестоимости.</p>
-          <div class="mt-2 w-full h-2 bg-slate-100 rounded-full overflow-hidden">
-            <div class="h-2 bg-brand-400 w-[55%]" id="rm2"></div>
-          </div>
-        </li>
-        <!-- 3 -->
-        <li class="mb-10 ms-6 reveal">
-          <span class="absolute -start-3 top-0 flex h-6 w-6 items-center justify-center rounded-full bg-brand-600 text-white text-xs">3</span>
-          <h3 class="font-semibold">Прототипы и тесты <span class="text-slate-400 font-normal">· 3–4 мес</span></h3>
-          <p class="text-slate-600 text-sm mt-1">Изготовление прототипов, тестирование, доработка конструкции.</p>
-          <div class="mt-2 w-full h-2 bg-slate-100 rounded-full overflow-hidden">
-            <div class="h-2 bg-brand-400 w-[25%]" id="rm3"></div>
-          </div>
-        </li>
-        <!-- 4 -->
-        <li class="ms-6 reveal">
-          <span class="absolute -start-3 top-0 flex h-6 w-6 items-center justify-center rounded-full bg-brand-600 text-white text-xs">4</span>
-          <h3 class="font-semibold">Производство и маркетинг <span class="text-slate-400 font-normal">· 4–6 мес</span></h3>
-          <p class="text-slate-600 text-sm mt-1">Пилотная партия, сертификация, запуск рекламы и продаж.</p>
-          <div class="mt-2 w-full h-2 bg-slate-100 rounded-full overflow-hidden">
-            <div class="h-2 bg-brand-400 w-[10%]" id="rm4"></div>
-          </div>
-        </li>
-      </ol>
-
-      <div class="mt-8 text-center reveal">
-        <a href="https://t.me/step_3d_mngr" target="_blank" rel="noopener" class="inline-flex items-center gap-2 rounded-2xl bg-brand-600 hover:bg-brand-700 text-white px-5 py-3 shadow-soft">
-          Связаться для демо
-        </a>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Report -->
-  <section id="report" class="py-16 md:py-24">
-    <div class="mx-auto max-w-7xl px-4">
-      <div class="reveal text-center">
-        <h2 class="text-2xl md:text-3xl font-extrabold">Полный отчёт проекта</h2>
-        <p class="mt-3 text-slate-600">Аналитика рынка, ТЗ, дорожная карта, базовая финмодель.</p>
-        <a href="https://docs.google.com/document/d/1rt-c9IXPk9TfibsPgENWii8aT75_IGGIeOkOGP7pX3g/edit?tab=t.0" target="_blank" rel="noopener" class="inline-flex items-center gap-2 mt-6 px-5 py-3 rounded-2xl border border-brand-200 bg-brand-50 text-brand-700 hover:bg-brand-100">
-          Ознакомиться с отчётом
-        </a>
+    <section id="specs" class="py-8">
+      <div class="mx-auto max-w-7xl px-4">
+        <div class="reveal grid md:grid-cols-2 gap-6">
+          <div class="bg-white rounded-3xl p-6 shadow-soft ring-1 ring-slate-100">
+            <h3 class="font-semibold">Технические характеристики</h3>
+            <ul class="mt-3 space-y-2 text-slate-700 text-sm">
+              <li>• Диапазон подъёма: 0–350 мм (настройка)</li>
+              <li>• Грузоподъёмность: 10–15 кг (домашняя ПММ)</li>
+              <li>• Габариты: компактные, проходят в стандартные проёмы</li>
+              <li>• Колёса: поворотные, фиксируемые</li>
+              <li>• Безопасность: демпфирование, механическая блокировка</li>
+            </ul>
+          </div>
+          <div class="bg-gradient-to-br from-brand-50 to-white rounded-3xl p-6 shadow-soft ring-1 ring-slate-100">
+            <h3 class="font-semibold">Преимущества</h3>
+            <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
+              <div class="bg-white rounded-2xl p-3 shadow">Снижение нагрузки на поясницу</div>
+              <div class="bg-white rounded-2xl p-3 shadow">Чистый внешний вид</div>
+              <div class="bg-white rounded-2xl p-3 shadow">Простая интеграция</div>
+              <div class="bg-white rounded-2xl p-3 shadow">Доступная себестоимость</div>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <!-- Footer -->
-  <footer class="py-10 border-t bg-white">
-    <div class="mx-auto max-w-7xl px-4 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-slate-600">
-      <div>© Step3D — идея-прототип</div>
-      <div class="flex items-center gap-4">
-        <a href="#home" class="hover:text-brand-700">Наверх</a>
-        <a href="https://t.me/step_3d_mngr" target="_blank" rel="noopener" class="hover:text-brand-700">Контакты</a>
-        <a href="#" class="hover:text-brand-700">Политика конфиденциальности</a>
+    <!-- Roadmap -->
+    <section id="roadmap" class="py-16 md:py-24 bg-white">
+      <div class="mx-auto max-w-7xl px-4">
+        <div class="reveal text-center">
+          <h2 class="text-2xl md:text-3xl font-extrabold">Дорожная карта</h2>
+          <p class="mt-3 text-slate-600">Этапы от исследования до серийного запуска.</p>
+        </div>
+
+        <!-- Progress timeline -->
+        <ol class="mt-10 relative border-s-2 border-brand-100 ps-6">
+          <!-- 1 -->
+          <li class="mb-10 ms-6 reveal">
+            <span class="absolute -start-3 top-0 flex h-6 w-6 items-center justify-center rounded-full bg-brand-600 text-white text-xs">1</span>
+            <h3 class="font-semibold">Исследование и UX <span class="text-slate-400 font-normal">· 1–2 мес</span></h3>
+            <p class="text-slate-600 text-sm mt-1">Опросы, фокус-группы, анализ патентов, сценарии использования.</p>
+            <div class="mt-2 w-full h-2 bg-slate-100 rounded-full overflow-hidden">
+              <div class="h-2 bg-brand-400 w-[85%]"></div>
+            </div>
+          </li>
+          <!-- 2 -->
+          <li class="mb-10 ms-6 reveal">
+            <span class="absolute -start-3 top-0 flex h-6 w-6 items-center justify-center rounded-full bg-brand-600 text-white text-xs">2</span>
+            <h3 class="font-semibold">Проектирование <span class="text-slate-400 font-normal">· 2–3 мес</span></h3>
+            <p class="text-slate-600 text-sm mt-1">3D-модели, чертежи, выбор поставщиков, расчёт себестоимости.</p>
+            <div class="mt-2 w-full h-2 bg-slate-100 rounded-full overflow-hidden">
+              <div class="h-2 bg-brand-400 w-[55%]" id="rm2"></div>
+            </div>
+          </li>
+          <!-- 3 -->
+          <li class="mb-10 ms-6 reveal">
+            <span class="absolute -start-3 top-0 flex h-6 w-6 items-center justify-center rounded-full bg-brand-600 text-white text-xs">3</span>
+            <h3 class="font-semibold">Прототипы и тесты <span class="text-slate-400 font-normal">· 3–4 мес</span></h3>
+            <p class="text-slate-600 text-sm mt-1">Изготовление прототипов, тестирование, доработка конструкции.</p>
+            <div class="mt-2 w-full h-2 bg-slate-100 rounded-full overflow-hidden">
+              <div class="h-2 bg-brand-400 w-[25%]" id="rm3"></div>
+            </div>
+          </li>
+          <!-- 4 -->
+          <li class="ms-6 reveal">
+            <span class="absolute -start-3 top-0 flex h-6 w-6 items-center justify-center rounded-full bg-brand-600 text-white text-xs">4</span>
+            <h3 class="font-semibold">Производство и маркетинг <span class="text-slate-400 font-normal">· 4–6 мес</span></h3>
+            <p class="text-slate-600 text-sm mt-1">Пилотная партия, сертификация, запуск рекламы и продаж.</p>
+            <div class="mt-2 w-full h-2 bg-slate-100 rounded-full overflow-hidden">
+              <div class="h-2 bg-brand-400 w-[10%]" id="rm4"></div>
+            </div>
+          </li>
+        </ol>
+
+        <div class="mt-8 text-center reveal">
+          <a href="https://t.me/step_3d_mngr" target="_blank" rel="noopener" class="inline-flex items-center gap-2 rounded-2xl bg-brand-600 hover:bg-brand-700 text-white px-5 py-3 shadow-soft">
+            Связаться для демо
+          </a>
+        </div>
       </div>
-    </div>
-  </footer>
+    </section>
+
+    <!-- Report -->
+    <section id="report" class="py-16 md:py-24">
+      <div class="mx-auto max-w-7xl px-4">
+        <div class="reveal text-center">
+          <h2 class="text-2xl md:text-3xl font-extrabold">Полный отчёт проекта</h2>
+          <p class="mt-3 text-slate-600">Аналитика рынка, ТЗ, дорожная карта, базовая финмодель.</p>
+          <a href="https://docs.google.com/document/d/1rt-c9IXPk9TfibsPgENWii8aT75_IGGIeOkOGP7pX3g/edit?tab=t.0" target="_blank" rel="noopener" class="inline-flex items-center gap-2 mt-6 px-5 py-3 rounded-2xl border border-brand-200 bg-brand-50 text-brand-700 hover:bg-brand-100">
+            Ознакомиться с отчётом
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="py-10 border-t bg-white">
+      <div class="mx-auto max-w-7xl px-4 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-slate-600">
+        <div>© Step3D — идея-прототип</div>
+        <div class="flex items-center gap-4">
+          <a href="#main-content" class="hover:text-brand-700">Наверх</a>
+          <a href="https://t.me/step_3d_mngr" target="_blank" rel="noopener" class="hover:text-brand-700">Контакты</a>
+          <a href="#" class="hover:text-brand-700">Политика конфиденциальности</a>
+        </div>
+      </div>
+    </footer>
+  </main>
 
   <script>
     // Mobile menu


### PR DESCRIPTION
## Summary
- wrap the home, problem, solution, specs, roadmap, report, and footer sections in a new <main id="main-content">
- move the global top padding classes onto the main element and keep inner sections intact
- update navigation anchors to reference the new main content container where appropriate

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdec65776c8333a877eff15c49b8cc